### PR TITLE
Fix endless recursion in getSvgsInDir helper

### DIFF
--- a/src/helpers/getSvgsInDir.js
+++ b/src/helpers/getSvgsInDir.js
@@ -10,7 +10,7 @@ export default function getSvgsInDir(dir) {
     const absolutePath = path.join(dir, file);
 
     if (fs.lstatSync(absolutePath).isDirectory()) {
-      return getSvgsInDir(dir, file);
+      return getSvgsInDir(absolutePath);
     }
 
     if (!absolutePath.match(/\.svg$/)) {


### PR DESCRIPTION
When `absolutePath` was a directory, it should be passed to recursion function.
Taking `dir, file` as parameters will cause endless recursion.